### PR TITLE
Configure CI for iOS code signing

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -9,8 +9,6 @@ name: Build iOS App
 jobs:
   build:
     runs-on: macos-latest
-    env:
-      DEVELOPMENT_TEAM: ${{ secrets.DEVELOPMENT_TEAM }}
 
     steps:
       - name: Checkout repository
@@ -21,17 +19,6 @@ jobs:
           brew install cocoapods
           pod install --project-directory=BambuManIOS || true
 
-      - name: Set up signing certificate
-        uses: apple-actions/import-codesign-certs@v2
-        with:
-          p12-file-base64: ${{ secrets.IOS_DIST_CERT }}
-          p12-password: ${{ secrets.IOS_DIST_CERT_PASSWORD }}
-
-      - name: Install provisioning profile
-        run: |
-          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-          echo "${{ secrets.IOS_PROVISION_PROFILE }}" > ~/Library/MobileDevice/Provisioning\ Profiles/profile.mobileprovision
-
       - name: Build IPA
         run: |
           xcodebuild \
@@ -40,7 +27,7 @@ jobs:
             -sdk iphoneos \
             -configuration Release \
             archive -archivePath $PWD/build/BambuManIOS.xcarchive \
-            DEVELOPMENT_TEAM=$DEVELOPMENT_TEAM
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
 
 
       - name: Export archive
@@ -50,7 +37,7 @@ jobs:
             -archivePath $PWD/build/BambuManIOS.xcarchive \
             -exportOptionsPlist ExportOptions.plist \
             -exportPath $PWD/build/ipa \
-            DEVELOPMENT_TEAM=$DEVELOPMENT_TEAM
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
 
 
       - name: Upload IPA

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -9,6 +9,8 @@ name: Build iOS App
 jobs:
   build:
     runs-on: macos-latest
+    env:
+      DEVELOPMENT_TEAM: ${{ secrets.DEVELOPMENT_TEAM }}
 
     steps:
       - name: Checkout repository
@@ -19,12 +21,18 @@ jobs:
           brew install cocoapods
           pod install --project-directory=BambuManIOS || true
 
+      - name: Set up signing certificate
+        uses: apple-actions/import-codesign-certs@v2
+        with:
+          p12-file-base64: ${{ secrets.IOS_DIST_CERT }}
+          p12-password: ${{ secrets.IOS_DIST_CERT_PASSWORD }}
+
+      - name: Install provisioning profile
+        run: |
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          echo "${{ secrets.IOS_PROVISION_PROFILE }}" > ~/Library/MobileDevice/Provisioning\ Profiles/profile.mobileprovision
 
       - name: Build IPA
-        env:
-          DEVELOPMENT_TEAM: ${{ secrets.APPLE_TEAM_ID }}
-          
-
         run: |
           xcodebuild \
             -project BambuManIOS.xcodeproj \
@@ -32,8 +40,7 @@ jobs:
             -sdk iphoneos \
             -configuration Release \
             archive -archivePath $PWD/build/BambuManIOS.xcarchive \
-
-            DEVELOPMENT_TEAM=$DEVELOPMENT_TEAM CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+            DEVELOPMENT_TEAM=$DEVELOPMENT_TEAM
 
 
       - name: Export archive


### PR DESCRIPTION
## Summary
- restore default signing settings in Xcode project
- import signing certificate and provisioning profile in iOS build workflow

## Testing
- `xcodebuild -version` *(fails: command not found)*
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_68baf8cee978832398bfb2fd8df1036c